### PR TITLE
TSVersionChecker: Fix version diff comparison

### DIFF
--- a/TSVersionChecker/src/tscheckversion.ts
+++ b/TSVersionChecker/src/tscheckversion.ts
@@ -82,7 +82,7 @@ switch (versionDiff) {
         setOutput(interopVersion, bumpedVersion, tsDumperVersion, latestTsVersion, VersionDiff[versionDiff].toLowerCase());
         break;
     }
-    case VersionDiff.Minor {
+    case VersionDiff.Minor: {
         const bumpedVersion = bumpMinorVersion(interopVersion);
         setOutput(interopVersion, bumpedVersion, tsDumperVersion, latestTsVersion, VersionDiff[versionDiff].toLowerCase());
         break;

--- a/TSVersionChecker/src/tscheckversion.ts
+++ b/TSVersionChecker/src/tscheckversion.ts
@@ -82,7 +82,12 @@ switch (versionDiff) {
         setOutput(interopVersion, bumpedVersion, tsDumperVersion, latestTsVersion, VersionDiff[versionDiff].toLowerCase());
         break;
     }
-    case VersionDiff.Minor || VersionDiff.Patch: {
+    case VersionDiff.Minor {
+        const bumpedVersion = bumpMinorVersion(interopVersion);
+        setOutput(interopVersion, bumpedVersion, tsDumperVersion, latestTsVersion, VersionDiff[versionDiff].toLowerCase());
+        break;
+    }
+    case VersionDiff.Patch: {
         const bumpedVersion = bumpMinorVersion(interopVersion);
         setOutput(interopVersion, bumpedVersion, tsDumperVersion, latestTsVersion, VersionDiff[versionDiff].toLowerCase());
         break;


### PR DESCRIPTION
Logical AND/OR does not work as expected in switch statements. Separated out into it's own case.