### PR TITLE
Interop+TSDumper: Bumping the Interop and TSDumper TypeScript version

### DIFF
--- a/Interop/Directory.Build.props
+++ b/Interop/Directory.Build.props
@@ -1,5 +1,5 @@
 <Project>
     <PropertyGroup>
-        <BlazorJavascriptInteropVersion>1.1.0</BlazorJavascriptInteropVersion>
+        <BlazorJavascriptInteropVersion>1.2.0</BlazorJavascriptInteropVersion>
     </PropertyGroup>
 </Project>

--- a/TSDumper/package.json
+++ b/TSDumper/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "ts-node": "10.5.0",
-    "typescript": "4.6.2"
+    "typescript": "4.6.3"
   },
   "devDependencies": {
     "@types/node": "17.0.18"


### PR DESCRIPTION
This bumps the TSDumper's TypeScript version from 4.6.2 to 4.6.3, which is a patch version bump. As a result, we are bumping the Interop project from version 1.1.0 to 1.2.0.
